### PR TITLE
Fix empty command and duplicate group error handling bugs

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -14,6 +14,7 @@ import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.group.exceptions.DuplicateGroupException;
 import seedu.address.model.person.Person;
 import seedu.address.storage.Storage;
 

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -14,7 +14,6 @@ import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.group.exceptions.DuplicateGroupException;
 import seedu.address.model.person.Person;
 import seedu.address.storage.Storage;
 

--- a/src/main/java/seedu/address/logic/commands/Command.java
+++ b/src/main/java/seedu/address/logic/commands/Command.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.group.exceptions.DuplicateGroupException;
 
 /**
  * Represents a command with hidden internal logic and the ability to be executed.
@@ -15,6 +16,6 @@ public abstract class Command {
      * @return feedback message of the operation result for display
      * @throws CommandException If an error occurs during command execution.
      */
-    public abstract CommandResult execute(Model model) throws CommandException;
+    public abstract CommandResult execute(Model model) throws CommandException, DuplicateGroupException;
 
 }

--- a/src/main/java/seedu/address/logic/commands/CreateGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreateGroupCommand.java
@@ -7,6 +7,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.group.Group;
 import seedu.address.model.group.GroupName;
+import seedu.address.model.group.exceptions.DuplicateGroupException;
 import seedu.address.model.person.Person;
 
 public class CreateGroupCommand extends Command {
@@ -31,7 +32,7 @@ public class CreateGroupCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model) throws CommandException {
+    public CommandResult execute(Model model) throws CommandException, DuplicateGroupException {
         requireNonNull(model);
         if (!validCommand) {
             return new CommandResult(MESSAGE_ERROR);

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -37,9 +37,11 @@ public class ArgumentTokenizer {
      * @return           ArgumentMultimap object that maps prefixes to their arguments
      */
     public static ArgumentMultimap tokenizeStringWithRepeatedPrefixes(String argsString, Prefix repeatedPrefix,
-                                                             Prefix... prefixes) {
-
+                                                                      Prefix... prefixes) {
         int startOfRepeatedPrefix = argsString.indexOf(" " + repeatedPrefix.getPrefix());
+        if (startOfRepeatedPrefix == -1) {
+            return new ArgumentMultimap();
+        }
         String stringWihoutRepeatedPrefixes = argsString.substring(0, startOfRepeatedPrefix);
 
         List<PrefixPosition> positions = findAllPrefixPositions(stringWihoutRepeatedPrefixes, prefixes);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -7,6 +7,7 @@ import java.util.List;
 import javafx.collections.ObservableList;
 import seedu.address.model.group.Group;
 import seedu.address.model.group.UniqueGroupList;
+import seedu.address.model.group.exceptions.DuplicateGroupException;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 
@@ -123,7 +124,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      * Adds group to unique group list.
      * @param group new Group object to be added.
      */
-    public void addGroup(Group group) {
+    public void addGroup(Group group) throws DuplicateGroupException {
         groups.add(group);
     }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.group.Group;
+import seedu.address.model.group.exceptions.DuplicateGroupException;
 import seedu.address.model.person.Person;
 
 /**
@@ -90,7 +91,7 @@ public interface Model {
      * Adds the given group.
      * {@code Group} must not already exist in the address book.
      */
-    void addGroup(Group person);
+    void addGroup(Group person) throws DuplicateGroupException;
 
     void deleteGroup(Group group);
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -12,6 +12,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.group.Group;
+import seedu.address.model.group.exceptions.DuplicateGroupException;
 import seedu.address.model.person.Person;
 
 /**
@@ -137,7 +138,7 @@ public class ModelManager implements Model {
      * @param group Group object representing members going on a trip.
      */
     @Override
-    public void addGroup(Group group) {
+    public void addGroup(Group group) throws DuplicateGroupException {
         addressBook.addGroup(group);
     }
 

--- a/src/main/java/seedu/address/model/group/UniqueGroupList.java
+++ b/src/main/java/seedu/address/model/group/UniqueGroupList.java
@@ -42,10 +42,10 @@ public class UniqueGroupList implements Iterable<Group> {
      * Adds a person to the list.
      * The person must not already exist in the list.
      */
-    public void add(Group toAdd) {
+    public void add(Group toAdd) throws DuplicateGroupException {
         requireNonNull(toAdd);
         if (contains(toAdd)) {
-            throw new DuplicatePersonException();
+            throw new DuplicateGroupException();
         }
         internalList.add(toAdd);
     }
@@ -55,7 +55,7 @@ public class UniqueGroupList implements Iterable<Group> {
      * {@code target} must exist in the list.
      * The group identity of {@code editedGroup} must not be the same as another existing group in the list.
      */
-    public void setGroup(Group target, Group editedGroup) {
+    public void setGroup(Group target, Group editedGroup) throws DuplicateGroupException {
         requireAllNonNull(target, editedGroup);
 
         int index = internalList.indexOf(target);

--- a/src/main/java/seedu/address/model/group/exceptions/DuplicateGroupException.java
+++ b/src/main/java/seedu/address/model/group/exceptions/DuplicateGroupException.java
@@ -1,4 +1,9 @@
 package seedu.address.model.group.exceptions;
 
-public class DuplicateGroupException extends RuntimeException {
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class DuplicateGroupException extends ParseException {
+    public DuplicateGroupException() {
+        super("Operation would result in duplicate groups");
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -17,6 +17,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
+import seedu.address.model.group.exceptions.DuplicateGroupException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
@@ -82,6 +83,8 @@ public class CommandTestUtil {
             assertEquals(expectedModel, actualModel);
         } catch (CommandException ce) {
             throw new AssertionError("Execution of command should not fail.", ce);
+        } catch (DuplicateGroupException dge) {
+            throw new AssertionError("Execution of command should not fail.", dge);
         }
     }
 


### PR DESCRIPTION
Bug: creategroup command without parameters did not show error.
Status: fixed

Bug: creategroup [GROUP_NAME] command where group with [GROUP_NAME] already exists was not handled properly.
Status: fixed