### PR TITLE
Add CreateGroupCommandTest.java

### DIFF
--- a/src/main/java/seedu/awe/logic/commands/CreateGroupCommand.java
+++ b/src/main/java/seedu/awe/logic/commands/CreateGroupCommand.java
@@ -26,6 +26,8 @@ public class CreateGroupCommand extends Command {
      * Creates a CreateGroupCommand to create the specified {@code Group}
      */
     public CreateGroupCommand(GroupName groupName, ArrayList<Person> members, boolean isValidCommand) {
+        requireNonNull(groupName);
+        requireNonNull(members);
         this.groupName = groupName;
         this.members = members;
         this.isValidCommand = isValidCommand;
@@ -39,6 +41,9 @@ public class CreateGroupCommand extends Command {
         }
 
         Group group = new Group(groupName, members);
+        if (model.hasGroup(group)) {
+            throw new CommandException(MESSAGE_DUPLICATE_GROUP);
+        }
         model.addGroup(group);
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/test/java/seedu/awe/logic/commands/CreateGroupCommandTest.java
+++ b/src/test/java/seedu/awe/logic/commands/CreateGroupCommandTest.java
@@ -1,16 +1,247 @@
 package seedu.awe.logic.commands;
 
-import static seedu.awe.testutil.TypicalGroups.getTypicalAddressBook;
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.awe.testutil.Assert.assertThrows;
 
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+
+import javafx.collections.ObservableList;
+import seedu.awe.commons.core.GuiSettings;
+import seedu.awe.logic.commands.exceptions.CommandException;
+import seedu.awe.model.AddressBook;
 import seedu.awe.model.Model;
-import seedu.awe.model.ModelManager;
-import seedu.awe.model.UserPrefs;
-import seedu.awe.model.group.exceptions.DuplicateGroupException;
+import seedu.awe.model.ReadOnlyAddressBook;
+import seedu.awe.model.ReadOnlyUserPrefs;
+import seedu.awe.model.group.Group;
+import seedu.awe.model.group.GroupName;
+import seedu.awe.model.person.Person;
+import seedu.awe.testutil.GroupBuilder;
+import seedu.awe.testutil.PersonBuilder;
+
+
 
 public class CreateGroupCommandTest {
     private Model model;
 
-    public CreateGroupCommandTest() throws DuplicateGroupException {
-        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    @Test
+    public void constructor_nullGroup_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                new CreateGroupCommand(null, null, true));
     }
+
+    @Test
+    public void execute_groupAcceptedByModel_addSuccessful() throws Exception {
+        ModelStubAcceptingGroupAdded modelStub = new ModelStubAcceptingGroupAdded();
+        GroupBuilder builder = new GroupBuilder();
+        GroupName venice = builder.getValidGroupName();
+        ArrayList<Person> members = builder.getValidMembers();
+        Group groupAdded = new Group(venice, members);
+
+        CommandResult commandResult = new CreateGroupCommand(venice, members, true).execute(modelStub);
+
+        assertEquals(CreateGroupCommand.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(groupAdded), modelStub.groupsAdded);
+    }
+
+    @Test
+    public void execute_duplicateGroup_throwsCommandException() {
+        Group validGroup = new GroupBuilder().buildValidGroup();
+        GroupBuilder builder = new GroupBuilder();
+        GroupName venice = builder.getValidGroupName();
+        ArrayList<Person> members = builder.getValidMembers();
+        CreateGroupCommand createGroupCommand = new CreateGroupCommand(venice, members, true);
+        ModelStub modelStub = new ModelStubWithGroup(validGroup);
+
+        assertThrows(CommandException.class, CreateGroupCommand.MESSAGE_DUPLICATE_GROUP, () ->
+                        createGroupCommand.execute(modelStub));
+    }
+
+    @Test
+    public void equals() {
+        Person alice = new PersonBuilder().withName("Alice").build();
+        Person bob = new PersonBuilder().withName("Bob").build();
+        AddCommand addAliceCommand = new AddCommand(alice);
+        AddCommand addBobCommand = new AddCommand(bob);
+
+        GroupName venice = new GroupName("Venice");
+        GroupName london = new GroupName("London");
+        ArrayList<Person> members = new GroupBuilder().getValidMembers();
+        CreateGroupCommand createVeniceCommand = new CreateGroupCommand(venice, members, true);
+        CreateGroupCommand createLondonCommand = new CreateGroupCommand(london, members, true);
+
+
+        // same object -> returns true
+        assertTrue(createVeniceCommand.equals(createVeniceCommand));
+        assertTrue(createLondonCommand.equals(createLondonCommand));
+
+        // different types -> returns false
+        assertFalse(createLondonCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(createLondonCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(createLondonCommand.equals(createVeniceCommand));
+    }
+
+    /**
+     * A default model stub that have all of the methods failing.
+     */
+    private class ModelStub implements Model {
+        @Override
+        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyUserPrefs getUserPrefs() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public GuiSettings getGuiSettings() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setGuiSettings(GuiSettings guiSettings) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Path getAddressBookFilePath() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAddressBookFilePath(Path addressBookFilePath) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAddressBook(ReadOnlyAddressBook newData) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyAddressBook getAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deletePerson(Person target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setPerson(Person target, Person editedPerson) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Person> getFilteredPersonList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteGroup(Group group) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasGroup(Group group) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        /**
+         * Returns an unmodifiable view of the list of {@code Group} backed by the internal list of
+         * {@code versionedAddressBook}
+         */
+        @Override
+        public ObservableList<Group> getFilteredGroupList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredGroupList(Predicate<Group> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Group getGroupByName(GroupName groupName) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addGroup(Group group) {
+            throw new AssertionError("This method should not be called.");
+        }
+    }
+
+    /**
+     * A Model stub that contains a single person.
+     */
+    private class ModelStubWithGroup extends ModelStub {
+        private final Group group;
+
+        ModelStubWithGroup(Group group) {
+            requireNonNull(group);
+            this.group = group;
+        }
+
+        @Override
+        public boolean hasGroup(Group group) {
+            requireNonNull(group);
+            return this.group.isSameGroup(group);
+        }
+    }
+
+    /**
+     * A Model stub that always accept the group being added.
+     */
+    private class ModelStubAcceptingGroupAdded extends ModelStub {
+        final ArrayList<Group> groupsAdded = new ArrayList<>();
+
+        @Override
+        public boolean hasGroup(Group group) {
+            requireNonNull(group);
+            return groupsAdded.stream().anyMatch(group::isSameGroup);
+        }
+
+        @Override
+        public void addGroup(Group group) {
+            requireNonNull(group);
+            groupsAdded.add(group);
+        }
+
+        @Override
+        public ReadOnlyAddressBook getAddressBook() {
+            return new AddressBook();
+        }
+    }
+
 }
+

--- a/src/test/java/seedu/awe/logic/parser/CreateGroupCommandParserTest.java
+++ b/src/test/java/seedu/awe/logic/parser/CreateGroupCommandParserTest.java
@@ -2,6 +2,6 @@ package seedu.awe.logic.parser;
 
 import seedu.awe.model.ModelManager;
 
-public class CreateGroupParserTest {
+public class CreateGroupCommandParserTest {
     private CreateGroupCommandParser parser = new CreateGroupCommandParser(new ModelManager());
 }

--- a/src/test/java/seedu/awe/testutil/GroupBuilder.java
+++ b/src/test/java/seedu/awe/testutil/GroupBuilder.java
@@ -78,4 +78,27 @@ public class GroupBuilder {
         return new Group(this.groupName, this.members, this.tags);
     }
 
+    /**
+     * Returns a valid Group object.
+     *
+     * @return Group object with default name "Venice" and default member "Amy Bee".
+     */
+    public Group buildValidGroup() {
+        GroupName venice = new GroupName("Venice");
+        ArrayList<Person> members = new ArrayList<Person>();
+        members.add(new PersonBuilder().build());
+        return new Group(venice, members);
+    }
+
+    public GroupName getValidGroupName() {
+        GroupName venice = new GroupName("Venice");
+        return venice;
+    }
+
+    public ArrayList<Person> getValidMembers() {
+        ArrayList<Person> members = new ArrayList<Person>();
+        members.add(new PersonBuilder().build());
+        return members;
+    }
+
 }


### PR DESCRIPTION
CreateGroupCommand does not check if groupname or members are null.
execute() method does not check if model already has a given group.
No tests for CreateGroupCommand.

Group is created with null parameters.
DuplicateGroupException thrown.

Check groupname and members with requireNonNull()
execute() method checks if model has given group.
Add CreateGroupCommandTest.java.

Constructor for CreateGroupCommand throws NullPointerException
when given null arguments.
execute() method throws CommandException when creating duplicate.
Tests covers CreateGroupCommand.