### PR TITLE
Add CreateGroupCommandTest and CreateGroupCommandParserTest

### DIFF
--- a/src/main/java/seedu/awe/logic/commands/CreateGroupCommand.java
+++ b/src/main/java/seedu/awe/logic/commands/CreateGroupCommand.java
@@ -33,6 +33,53 @@ public class CreateGroupCommand extends Command {
         this.isValidCommand = isValidCommand;
     }
 
+    public ArrayList<Person> getMembers() {
+        return members;
+    }
+
+    public GroupName getGroupName() {
+        return groupName;
+    }
+
+    public boolean getValidCommand() {
+        return isValidCommand;
+    }
+
+    /**
+     * Returns int object tracking the number of non matching members between this.members and otherMembers.
+     * @param numberOfNonMatchingMembers int value to track the number of members in otherMembers
+     *                                   that are not present in this.members.
+     * @param member Person object that is being searched for in otherMembers.
+     * @param otherMembers List of Person objects from another instance of CreateGroupCommand.
+     * @return int object to track the number of members in otherMembers that are not present in this.members.
+     */
+    public int checkForMember(int numberOfNonMatchingMembers, Person member, ArrayList<Person> otherMembers) {
+        for (Person otherMember : otherMembers) {
+            if (member.equals(otherMember)) {
+                numberOfNonMatchingMembers--;
+                break;
+            }
+        }
+        return numberOfNonMatchingMembers;
+    }
+
+    /**
+     * Returns a boolean object representing if this.members contains the same Person objects as otherMembers.
+     * @param otherMembers List of Person objects from another instance of CreateGroupCommand.
+     * @return boolean object representing if this.members contains the same Person objects as otherMembers.
+     */
+    public boolean checkSameMembers(ArrayList<Person> otherMembers) {
+        int numberOfNonMatchingMembers = otherMembers.size();
+        for (Person member : this.members) {
+            numberOfNonMatchingMembers = checkForMember(numberOfNonMatchingMembers, member, otherMembers);
+        }
+        if (numberOfNonMatchingMembers == 0) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     @Override
     public CommandResult execute(Model model) throws CommandException, DuplicateGroupException {
         requireNonNull(model);
@@ -46,5 +93,19 @@ public class CreateGroupCommand extends Command {
         }
         model.addGroup(group);
         return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other instanceof CreateGroupCommand) {
+            CreateGroupCommand otherCommand = (CreateGroupCommand) other;
+            if (this.isValidCommand == (otherCommand.getValidCommand())
+                    && checkSameMembers(otherCommand.getMembers())
+                    && this.groupName.equals(otherCommand.getGroupName())) {
+                return true;
+            }
+            return false;
+        }
+        return false;
     }
 }

--- a/src/main/java/seedu/awe/logic/commands/CreateGroupCommand.java
+++ b/src/main/java/seedu/awe/logic/commands/CreateGroupCommand.java
@@ -47,6 +47,7 @@ public class CreateGroupCommand extends Command {
 
     /**
      * Returns int object tracking the number of non matching members between this.members and otherMembers.
+     *
      * @param numberOfNonMatchingMembers int value to track the number of members in otherMembers
      *                                   that are not present in this.members.
      * @param member Person object that is being searched for in otherMembers.
@@ -65,6 +66,7 @@ public class CreateGroupCommand extends Command {
 
     /**
      * Returns a boolean object representing if this.members contains the same Person objects as otherMembers.
+     *
      * @param otherMembers List of Person objects from another instance of CreateGroupCommand.
      * @return boolean object representing if this.members contains the same Person objects as otherMembers.
      */
@@ -73,11 +75,7 @@ public class CreateGroupCommand extends Command {
         for (Person member : this.members) {
             numberOfNonMatchingMembers = checkForMember(numberOfNonMatchingMembers, member, otherMembers);
         }
-        if (numberOfNonMatchingMembers == 0) {
-            return true;
-        } else {
-            return false;
-        }
+        return numberOfNonMatchingMembers == 0;
     }
 
     @Override
@@ -97,14 +95,14 @@ public class CreateGroupCommand extends Command {
 
     @Override
     public boolean equals(Object other) {
-        if (other instanceof CreateGroupCommand) {
-            CreateGroupCommand otherCommand = (CreateGroupCommand) other;
-            if (this.isValidCommand == (otherCommand.getValidCommand())
-                    && checkSameMembers(otherCommand.getMembers())
-                    && this.groupName.equals(otherCommand.getGroupName())) {
-                return true;
-            }
+        if (!(other instanceof CreateGroupCommand)) {
             return false;
+        }
+        CreateGroupCommand otherCommand = (CreateGroupCommand) other;
+        if (this.isValidCommand == (otherCommand.getValidCommand())
+                && checkSameMembers(otherCommand.getMembers())
+                && this.groupName.equals(otherCommand.getGroupName())) {
+            return true;
         }
         return false;
     }

--- a/src/main/java/seedu/awe/logic/parser/CreateGroupCommandParser.java
+++ b/src/main/java/seedu/awe/logic/parser/CreateGroupCommandParser.java
@@ -99,15 +99,23 @@ public class CreateGroupCommandParser implements Parser<CreateGroupCommand> {
             int nextPrefix = teamMembers.indexOf(prefixWithWhiteSpace);
             while (nextPrefix != -1) {
                 Name memberName = new Name(teamMembers.substring(0, nextPrefix));
+                if (containsMemberName(memberName)) {
+                    teamMembers = teamMembers.substring(nextPrefix + 3);
+                    nextPrefix = teamMembers.indexOf(prefixWithWhiteSpace);
+                    continue;
+                }
                 if (Objects.isNull(addMemberIfExist(memberName))) {
                     return null;
                 }
                 teamMembers = teamMembers.substring(nextPrefix + 3);
                 nextPrefix = teamMembers.indexOf(prefixWithWhiteSpace);
             }
-            if (Objects.isNull(addMemberIfExist(new Name(teamMembers)))) {
-                return null;
+            if (!containsMemberName(new Name(teamMembers))) {
+                if (Objects.isNull(addMemberIfExist(new Name(teamMembers)))) {
+                    return null;
+                }
             }
+
             if (toBeAddedToGroup.size() == 0) {
                 throw new EmptyGroupException(MESSAGE_EMPTY_GROUP);
             } else {
@@ -154,6 +162,21 @@ public class CreateGroupCommandParser implements Parser<CreateGroupCommand> {
             }
         }
         return null;
+    }
+
+    /**
+     * Returns boolean representing if toBeAddedToGroup contains a member with the same name as the given name.
+     *
+     * @param memberName Name object that belongs to a member.
+     * @return boolean object representing if toBeAddedToGroup contains a member with the same name as the given name.
+     */
+    private boolean containsMemberName(Name memberName) {
+        for (Person member : toBeAddedToGroup) {
+            if (member.getName().equals(memberName)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/seedu/awe/model/group/Group.java
+++ b/src/main/java/seedu/awe/model/group/Group.java
@@ -9,7 +9,7 @@ import seedu.awe.model.person.Person;
 import seedu.awe.model.tag.Tag;
 
 public class Group {
-    public static final String MESSAGE_CONSTRAINTS = "MESSAGE_CONSTRAINT TO BE COMPLETED";
+    public static final String MESSAGE_CONSTRAINTS = "Group names should comprise of alphanumeric characters";
     //TODO: WRITE MESSAGE CONSTRAINTS MESSAGE
     private GroupName groupName;
     private final ArrayList<Person> members = new ArrayList<>();

--- a/src/test/java/seedu/awe/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/awe/logic/commands/CommandTestUtil.java
@@ -30,6 +30,7 @@ public class CommandTestUtil {
 
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
+    public static final String VALID_NAME_ALICE = "Alice Pauline";
     public static final String VALID_PHONE_AMY = "11111111";
     public static final String VALID_PHONE_BOB = "22222222";
     public static final String VALID_EMAIL_AMY = "amy@example.com";
@@ -46,6 +47,7 @@ public class CommandTestUtil {
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
+    public static final String NAME_DESC_ALICE = " " + PREFIX_NAME + VALID_NAME_ALICE;
     public static final String PHONE_DESC_AMY = " " + PREFIX_PHONE + VALID_PHONE_AMY;
     public static final String PHONE_DESC_BOB = " " + PREFIX_PHONE + VALID_PHONE_BOB;
     public static final String EMAIL_DESC_AMY = " " + PREFIX_EMAIL + VALID_EMAIL_AMY;

--- a/src/test/java/seedu/awe/logic/commands/CreateGroupCommandTest.java
+++ b/src/test/java/seedu/awe/logic/commands/CreateGroupCommandTest.java
@@ -24,9 +24,6 @@ import seedu.awe.model.group.Group;
 import seedu.awe.model.group.GroupName;
 import seedu.awe.model.person.Person;
 import seedu.awe.testutil.GroupBuilder;
-import seedu.awe.testutil.PersonBuilder;
-
-
 
 public class CreateGroupCommandTest {
     private Model model;
@@ -41,11 +38,11 @@ public class CreateGroupCommandTest {
     public void execute_groupAcceptedByModel_addSuccessful() throws Exception {
         ModelStubAcceptingGroupAdded modelStub = new ModelStubAcceptingGroupAdded();
         GroupBuilder builder = new GroupBuilder();
-        GroupName venice = builder.getValidGroupName();
+        GroupName bali = builder.getValidGroupName();
         ArrayList<Person> members = builder.getValidMembers();
-        Group groupAdded = new Group(venice, members);
+        Group groupAdded = new Group(bali, members);
 
-        CommandResult commandResult = new CreateGroupCommand(venice, members, true).execute(modelStub);
+        CommandResult commandResult = new CreateGroupCommand(bali, members, true).execute(modelStub);
 
         assertEquals(CreateGroupCommand.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(groupAdded), modelStub.groupsAdded);
@@ -55,9 +52,9 @@ public class CreateGroupCommandTest {
     public void execute_duplicateGroup_throwsCommandException() {
         Group validGroup = new GroupBuilder().buildValidGroup();
         GroupBuilder builder = new GroupBuilder();
-        GroupName venice = builder.getValidGroupName();
+        GroupName bali = builder.getValidGroupName();
         ArrayList<Person> members = builder.getValidMembers();
-        CreateGroupCommand createGroupCommand = new CreateGroupCommand(venice, members, true);
+        CreateGroupCommand createGroupCommand = new CreateGroupCommand(bali, members, true);
         ModelStub modelStub = new ModelStubWithGroup(validGroup);
 
         assertThrows(CommandException.class, CreateGroupCommand.MESSAGE_DUPLICATE_GROUP, () ->
@@ -66,30 +63,25 @@ public class CreateGroupCommandTest {
 
     @Test
     public void equals() {
-        Person alice = new PersonBuilder().withName("Alice").build();
-        Person bob = new PersonBuilder().withName("Bob").build();
-        AddCommand addAliceCommand = new AddCommand(alice);
-        AddCommand addBobCommand = new AddCommand(bob);
-
-        GroupName venice = new GroupName("Venice");
-        GroupName london = new GroupName("London");
+        GroupName bali = new GroupName("Bali");
+        GroupName oslo = new GroupName("Oslo");
         ArrayList<Person> members = new GroupBuilder().getValidMembers();
-        CreateGroupCommand createVeniceCommand = new CreateGroupCommand(venice, members, true);
-        CreateGroupCommand createLondonCommand = new CreateGroupCommand(london, members, true);
+        CreateGroupCommand createBaliCommand = new CreateGroupCommand(bali, members, true);
+        CreateGroupCommand createOsloCommand = new CreateGroupCommand(oslo, members, true);
 
 
         // same object -> returns true
-        assertTrue(createVeniceCommand.equals(createVeniceCommand));
-        assertTrue(createLondonCommand.equals(createLondonCommand));
+        assertTrue(createBaliCommand.equals(createBaliCommand));
+        assertTrue(createOsloCommand.equals(createOsloCommand));
 
         // different types -> returns false
-        assertFalse(createLondonCommand.equals(1));
+        assertFalse(createOsloCommand.equals(1));
 
         // null -> returns false
-        assertFalse(createLondonCommand.equals(null));
+        assertFalse(createOsloCommand.equals(null));
 
         // different person -> returns false
-        assertFalse(createLondonCommand.equals(createVeniceCommand));
+        assertFalse(createOsloCommand.equals(createBaliCommand));
     }
 
     /**

--- a/src/test/java/seedu/awe/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/awe/logic/parser/AddCommandParserTest.java
@@ -63,7 +63,7 @@ public class AddCommandParserTest {
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_AMY + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
 
-        // multiple addresses - last awe accepted
+        // multiple addresses - last address accepted
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_AMY
                 + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
 

--- a/src/test/java/seedu/awe/logic/parser/CreateGroupCommandParserTest.java
+++ b/src/test/java/seedu/awe/logic/parser/CreateGroupCommandParserTest.java
@@ -38,24 +38,21 @@ public class CreateGroupCommandParserTest {
     @Test
     public void parse_allFieldsPresent_success() {
         GroupName expectedGroupName = BALI.getGroupName();
-        ArrayList<Person> expectedGroupMembers = new ArrayList<>();
-        expectedGroupMembers.addAll(BALI.getMembers());
+        ArrayList<Person> expectedGroupMembers = new ArrayList<>(BALI.getMembers());
 
         // regular input for CreateGroupCommand
-        assertParseSuccess(parser, GROUPNAME_DESC_BALI
-                        + NAME_DESC_ALICE + NAME_DESC_BOB + NAME_DESC_AMY,
+        assertParseSuccess(parser, GROUPNAME_DESC_BALI + NAME_DESC_ALICE + NAME_DESC_BOB + NAME_DESC_AMY,
                 new CreateGroupCommand(expectedGroupName, expectedGroupMembers, true));
 
         resetParser();
         // names in different order
-        assertParseSuccess(parser, GROUPNAME_DESC_BALI
-                        + NAME_DESC_BOB + NAME_DESC_AMY + NAME_DESC_ALICE,
+        assertParseSuccess(parser, GROUPNAME_DESC_BALI + NAME_DESC_BOB + NAME_DESC_AMY + NAME_DESC_ALICE,
                 new CreateGroupCommand(expectedGroupName, expectedGroupMembers, true));
 
         resetParser();
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + GROUPNAME_DESC_BALI
-                + NAME_DESC_ALICE + NAME_DESC_BOB + NAME_DESC_AMY,
+                        + NAME_DESC_ALICE + NAME_DESC_BOB + NAME_DESC_AMY,
                 new CreateGroupCommand(expectedGroupName, expectedGroupMembers, true));
 
         resetParser();
@@ -69,10 +66,6 @@ public class CreateGroupCommandParserTest {
         assertParseSuccess(parser, GROUPNAME_DESC_BALI
                         + NAME_DESC_BOB + NAME_DESC_BOB + NAME_DESC_AMY + NAME_DESC_ALICE + NAME_DESC_ALICE,
                 new CreateGroupCommand(expectedGroupName, expectedGroupMembers, true));
-
-        resetParser();
-        // Command fails if more than one group name is detected
-
     }
 
     @Test

--- a/src/test/java/seedu/awe/logic/parser/CreateGroupCommandParserTest.java
+++ b/src/test/java/seedu/awe/logic/parser/CreateGroupCommandParserTest.java
@@ -1,7 +1,109 @@
 package seedu.awe.logic.parser;
 
-import seedu.awe.model.ModelManager;
+import static seedu.awe.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.awe.logic.commands.CommandTestUtil.GROUPNAME_DESC_BALI;
+import static seedu.awe.logic.commands.CommandTestUtil.INVALID_GROUP_NAME_DESC;
+import static seedu.awe.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
+import static seedu.awe.logic.commands.CommandTestUtil.NAME_DESC_ALICE;
+import static seedu.awe.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static seedu.awe.logic.commands.CommandTestUtil.NAME_DESC_BOB;
+import static seedu.awe.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static seedu.awe.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.awe.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.awe.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.awe.testutil.Assert.assertThrows;
+import static seedu.awe.testutil.TypicalGroups.BALI;
+
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.awe.logic.commands.CreateGroupCommand;
+import seedu.awe.model.group.Group;
+import seedu.awe.model.group.GroupName;
+import seedu.awe.model.person.Person;
+import seedu.awe.testutil.ModelBuilder;
 
 public class CreateGroupCommandParserTest {
-    private CreateGroupCommandParser parser = new CreateGroupCommandParser(new ModelManager());
+    private CreateGroupCommandParser parser = new CreateGroupCommandParser(new ModelBuilder().build());
+
+    /**
+     * Resets parser. Necessary as CreateGroupCommand parser needs to be initialised with a model for each call.
+     * Failure to reset parser will result in Duplicate exceptions being raised.
+     */
+    public void resetParser() {
+        parser = new CreateGroupCommandParser(new ModelBuilder().build());
+    }
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        GroupName expectedGroupName = BALI.getGroupName();
+        ArrayList<Person> expectedGroupMembers = new ArrayList<>();
+        expectedGroupMembers.addAll(BALI.getMembers());
+
+        // regular input for CreateGroupCommand
+        assertParseSuccess(parser, GROUPNAME_DESC_BALI
+                        + NAME_DESC_ALICE + NAME_DESC_BOB + NAME_DESC_AMY,
+                new CreateGroupCommand(expectedGroupName, expectedGroupMembers, true));
+
+        resetParser();
+        // names in different order
+        assertParseSuccess(parser, GROUPNAME_DESC_BALI
+                        + NAME_DESC_BOB + NAME_DESC_AMY + NAME_DESC_ALICE,
+                new CreateGroupCommand(expectedGroupName, expectedGroupMembers, true));
+
+        resetParser();
+        // whitespace only preamble
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + GROUPNAME_DESC_BALI
+                + NAME_DESC_ALICE + NAME_DESC_BOB + NAME_DESC_AMY,
+                new CreateGroupCommand(expectedGroupName, expectedGroupMembers, true));
+
+        resetParser();
+        // name repeats
+        assertParseSuccess(parser, GROUPNAME_DESC_BALI
+                        + NAME_DESC_BOB + NAME_DESC_AMY + NAME_DESC_ALICE + NAME_DESC_ALICE,
+                new CreateGroupCommand(expectedGroupName, expectedGroupMembers, true));
+
+        resetParser();
+        // multiple name repeats
+        assertParseSuccess(parser, GROUPNAME_DESC_BALI
+                        + NAME_DESC_BOB + NAME_DESC_BOB + NAME_DESC_AMY + NAME_DESC_ALICE + NAME_DESC_ALICE,
+                new CreateGroupCommand(expectedGroupName, expectedGroupMembers, true));
+
+        resetParser();
+        // Command fails if more than one group name is detected
+
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateGroupCommand.MESSAGE_USAGE);
+
+        resetParser();
+        // missing group prefix
+        assertParseFailure(parser, NAME_DESC_BOB + NAME_DESC_AMY + NAME_DESC_ALICE, expectedMessage);
+
+        resetParser();
+        // missing name prefix
+        assertParseFailure(parser, GROUPNAME_DESC_BALI, expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateGroupCommand.MESSAGE_USAGE);
+        resetParser();
+        // invalid group name
+        assertParseFailure(parser, INVALID_GROUP_NAME_DESC + NAME_DESC_BOB + NAME_DESC_AMY + NAME_DESC_ALICE,
+                Group.MESSAGE_CONSTRAINTS);
+
+        resetParser();
+        // invalid name returns IllegalArgumentException
+        String userInput = GROUPNAME_DESC_BALI + INVALID_NAME_DESC + NAME_DESC_AMY + NAME_DESC_ALICE;
+        assertThrows(IllegalArgumentException.class, GroupName.MESSAGE_CONSTRAINTS, () -> parser.parse(userInput));
+
+        resetParser();
+        // non-empty preamble
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + GROUPNAME_DESC_BALI
+                        + NAME_DESC_ALICE + NAME_DESC_BOB + NAME_DESC_AMY, expectedMessage);
+    }
 }

--- a/src/test/java/seedu/awe/testutil/GroupBuilder.java
+++ b/src/test/java/seedu/awe/testutil/GroupBuilder.java
@@ -81,22 +81,22 @@ public class GroupBuilder {
     /**
      * Returns a valid Group object.
      *
-     * @return Group object with default name "Venice" and default member "Amy Bee".
+     * @return Group object with default name "Bali" and default member "Amy Bee".
      */
     public Group buildValidGroup() {
-        GroupName venice = new GroupName("Venice");
+        GroupName bali = new GroupName("Bali");
         ArrayList<Person> members = new ArrayList<Person>();
         members.add(new PersonBuilder().build());
-        return new Group(venice, members);
+        return new Group(bali, members);
     }
 
     public GroupName getValidGroupName() {
-        GroupName venice = new GroupName("Venice");
-        return venice;
+        GroupName bali = new GroupName("Bali");
+        return bali;
     }
 
     public ArrayList<Person> getValidMembers() {
-        ArrayList<Person> members = new ArrayList<Person>();
+        ArrayList<Person> members = new ArrayList<>();
         members.add(new PersonBuilder().build());
         return members;
     }

--- a/src/test/java/seedu/awe/testutil/ModelBuilder.java
+++ b/src/test/java/seedu/awe/testutil/ModelBuilder.java
@@ -1,0 +1,100 @@
+package seedu.awe.testutil;
+import static seedu.awe.testutil.TypicalPersons.ALICE;
+import static seedu.awe.testutil.TypicalPersons.AMY;
+import static seedu.awe.testutil.TypicalPersons.BENSON;
+import static seedu.awe.testutil.TypicalPersons.BOB;
+import static seedu.awe.testutil.TypicalPersons.CARL;
+import static seedu.awe.testutil.TypicalPersons.DANIEL;
+import static seedu.awe.testutil.TypicalPersons.ELLE;
+import static seedu.awe.testutil.TypicalPersons.FIONA;
+import static seedu.awe.testutil.TypicalPersons.GEORGE;
+import static seedu.awe.testutil.TypicalPersons.HOON;
+import static seedu.awe.testutil.TypicalPersons.IDA;
+
+import javafx.collections.transformation.FilteredList;
+import seedu.awe.model.AddressBook;
+import seedu.awe.model.Model;
+import seedu.awe.model.ModelManager;
+import seedu.awe.model.UserPrefs;
+import seedu.awe.model.group.Group;
+import seedu.awe.model.person.Person;
+
+/**
+ * A utility class to help with building Person objects.
+ */
+public class ModelBuilder {
+
+    public static final AddressBook DEFAULT_ADDRESSBOOK = new AddressBook();
+    public static final UserPrefs DEFAULT_USERPREFS = new UserPrefs();
+    public static final FilteredList<Person> DEFAULT_FILTEREDPERSONS =
+            new FilteredList<Person>(DEFAULT_ADDRESSBOOK.getPersonList());
+    public static final FilteredList<Group> DEFAULT_FILTEREDGROUPS =
+            new FilteredList<Group>(DEFAULT_ADDRESSBOOK.getGroupList());
+
+    private AddressBook addressBook;
+    private UserPrefs userPrefs;
+    private FilteredList<Person> filteredPersons;
+    private FilteredList<Group> filteredGroups;
+
+    /**
+     * Creates a {@code ModelBuilder} with the default details.
+     */
+    public ModelBuilder() {
+        addressBook = new AddressBook();
+        addTypicalPersons(addressBook);
+        userPrefs = DEFAULT_USERPREFS;
+        filteredPersons = DEFAULT_FILTEREDPERSONS;
+        filteredGroups = DEFAULT_FILTEREDGROUPS;
+    }
+
+    /**
+     * Initializes the ModelBuilder with the data of {@code ModelToCopy}.
+     */
+    public ModelBuilder(Model modelToCopy) {
+        addressBook = (AddressBook) modelToCopy.getAddressBook();
+        userPrefs = (UserPrefs) modelToCopy.getUserPrefs();
+        filteredPersons = (FilteredList<Person>) modelToCopy.getFilteredPersonList();
+        filteredGroups = (FilteredList<Group>) modelToCopy.getFilteredGroupList();
+    }
+
+    /**
+     * Sets the {@code AddressBook} of the {@code Model} that we are building.
+     */
+    public ModelBuilder withAddressBook(AddressBook addressBook) {
+        this.addressBook = addressBook;
+        return this;
+    }
+
+    /**
+     * Sets the {@code UserPrefs} of the {@code Model} that we are building.
+     */
+    public ModelBuilder withUserPrefs(UserPrefs userPrefs) {
+        this.userPrefs = userPrefs;
+        return this;
+    }
+
+    /**
+     * Adds all Person attributes from TypicalPersons into the sample addressbook.
+     *
+     * @param addressBook AddressBook object to be used for testing purposes.
+     */
+    public void addTypicalPersons(AddressBook addressBook) {
+        addressBook.addPerson(ALICE);
+        addressBook.addPerson(BENSON);
+        addressBook.addPerson(CARL);
+        addressBook.addPerson(DANIEL);
+        addressBook.addPerson(ELLE);
+        addressBook.addPerson(FIONA);
+        addressBook.addPerson(GEORGE);
+        addressBook.addPerson(HOON);
+        addressBook.addPerson(IDA);
+        addressBook.addPerson(AMY);
+        addressBook.addPerson(BOB);
+    }
+
+    public Model build() {
+        return new ModelManager(addressBook, userPrefs);
+    }
+
+}
+

--- a/src/test/java/seedu/awe/testutil/TypicalGroups.java
+++ b/src/test/java/seedu/awe/testutil/TypicalGroups.java
@@ -28,7 +28,7 @@ public class TypicalGroups {
 
     public static final Group BALI = new GroupBuilder().withGroupName("Bali")
             .withMembers(ALICE, BOB, AMY)
-            .withTags("friends").build();
+            .build();
     public static final Group OSLO = new GroupBuilder().withGroupName("Oslo")
             .withMembers(CARL, ELLE, DANIEL)
             .withTags("friends").build();


### PR DESCRIPTION
CreateGroupCommand does not contain equals() method.
CreateGroupCommandParser does not check for repeated names.
Group.MESSAGE_CONSTRAINTS contain placeholder text.
No abstraction to create Model objects efficiently for testing.
No tests for CreateGroupCommandParser.

Unable to check equality between instances of CreateGroupCommand.
Unable to use creategroup command with repeat names.
Placeholder text displayed when use creategroup command with
invalid group member name.
Inconvenient to create Model objects for testing.
Tests for CreateGroupCommandParser should be automated.

Add equal method to CreateGroupCommand.
Modify CreateGroupCommandParser to handle repeat names
in creategroup command.
Replace placeholder text for Group.MESSAGE_CONTRAINTS.
Add ModelBuilder.
Add CreateGroupCommandParserTest.

Equality between CreateGroupCommand objects can be checked.
creategroup command can function with repeated names.
Only a repeated members will only be added to the group once.
Relevant error text displayed when use creategroup command with
invalid group member name.
Model objects can be created easily for testing.
Tests cover CreateGroupCommandParser.