### PR TITLE
Add groupaddperson and groupremoveperson functionality

### DIFF
--- a/src/main/java/seedu/awe/logic/commands/GroupAddPersonCommand.java
+++ b/src/main/java/seedu/awe/logic/commands/GroupAddPersonCommand.java
@@ -1,0 +1,113 @@
+package seedu.awe.logic.commands;
+import static java.util.Objects.requireNonNull;
+import static seedu.awe.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.ArrayList;
+
+import seedu.awe.logic.commands.exceptions.CommandException;
+import seedu.awe.model.Model;
+import seedu.awe.model.group.Group;
+import seedu.awe.model.group.GroupName;
+import seedu.awe.model.person.Person;
+
+public class GroupAddPersonCommand extends Command {
+    public static final String COMMAND_WORD = "groupaddperson";
+    public static final String MESSAGE_SUCCESS = "New member(s) added to group";
+    public static final String MESSAGE_ERROR = "Person(s) not added. Be sure to use the exact names of group members";
+    public static final String MESSAGE_DUPLICATE_PERSON = "%1$s is already in the group";
+    public static final String MESSAGE_USAGE = "groupaddperson gn/[GROUPNAME] n/[NAME1] n/[OPTIONAL NAME2]";
+
+    private final GroupName groupName;
+    private final ArrayList<Person> newMembers;
+    private final boolean isValidCommand;
+
+    /**
+     * Creates a GroupAddPersonCommand to add the specified {@code Person}
+     */
+    public GroupAddPersonCommand(GroupName groupName, ArrayList<Person> newMembers, boolean isValidCommand) {
+        requireAllNonNull(groupName, newMembers, isValidCommand);
+        this.groupName = groupName;
+        this.newMembers = newMembers;
+        this.isValidCommand = isValidCommand;
+    }
+
+    public GroupName getGroupName() {
+        return groupName;
+    }
+
+    public ArrayList<Person> getNewMembers() {
+        return newMembers;
+    }
+
+    public boolean getValidCommand() {
+        return isValidCommand;
+    }
+
+    /**
+     * Returns int object tracking the number of non-matching members between this.newMembers and otherMembers.
+     *
+     * @param numberOfNonMatchingMembers int value to track the number of members in otherMembers
+     *                                   that are not present in this.members.
+     * @param member Person object that is being searched for in otherMembers.
+     * @param otherMembers List of Person objects from another instance of CreateGroupCommand.
+     * @return int object to track the number of members in otherMembers that are not present in this.newMembers.
+     */
+    public int checkForMember(int numberOfNonMatchingMembers, Person member, ArrayList<Person> otherMembers) {
+        for (Person otherMember : otherMembers) {
+            if (member.equals(otherMember)) {
+                numberOfNonMatchingMembers--;
+                break;
+            }
+        }
+        return numberOfNonMatchingMembers;
+    }
+
+    /**
+     * Returns a boolean object representing if this.newMembers contains the same Person objects as otherMembers.
+     *
+     * @param otherMembers List of Person objects from another instance of CreateGroupCommand.
+     * @return boolean object representing if this.newMembers contains the same Person objects as otherMembers.
+     */
+    public boolean checkSameMembers(ArrayList<Person> otherMembers) {
+        int numberOfNonMatchingMembers = otherMembers.size();
+        for (Person member : this.newMembers) {
+            numberOfNonMatchingMembers = checkForMember(numberOfNonMatchingMembers, member, otherMembers);
+        }
+        return numberOfNonMatchingMembers == 0;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        if (!isValidCommand) {
+            return new CommandResult(MESSAGE_ERROR);
+        }
+
+        Group oldGroup = model.getGroupByName(groupName);
+        ArrayList<Person> membersFromOldGroup = oldGroup.getMembers();
+        for (Person member : newMembers) {
+            if (membersFromOldGroup.contains(member)) {
+                throw new CommandException(String.format(MESSAGE_DUPLICATE_PERSON, member.getName()));
+            }
+        }
+        newMembers.addAll(membersFromOldGroup);
+        Group newGroup = new Group(groupName, newMembers, oldGroup.getTags());
+        model.deleteGroup(oldGroup);
+        model.addGroup(newGroup);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof GroupAddPersonCommand)) {
+            return false;
+        }
+        GroupAddPersonCommand otherCommand = (GroupAddPersonCommand) other;
+        if (this.isValidCommand == (otherCommand.getValidCommand())
+                && checkSameMembers(otherCommand.getNewMembers())
+                && this.groupName.equals(otherCommand.getGroupName())) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/seedu/awe/logic/commands/GroupAddPersonCommand.java
+++ b/src/main/java/seedu/awe/logic/commands/GroupAddPersonCommand.java
@@ -80,7 +80,7 @@ public class GroupAddPersonCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         if (!isValidCommand) {
-            return new CommandResult(MESSAGE_ERROR);
+            throw new CommandException(MESSAGE_ERROR);
         }
 
         Group oldGroup = model.getGroupByName(groupName);

--- a/src/main/java/seedu/awe/logic/commands/GroupRemovePersonCommand.java
+++ b/src/main/java/seedu/awe/logic/commands/GroupRemovePersonCommand.java
@@ -1,0 +1,117 @@
+package seedu.awe.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.awe.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.ArrayList;
+
+import seedu.awe.logic.commands.exceptions.CommandException;
+import seedu.awe.model.Model;
+import seedu.awe.model.group.Group;
+import seedu.awe.model.group.GroupName;
+import seedu.awe.model.person.Person;
+
+public class GroupRemovePersonCommand extends Command {
+    public static final String COMMAND_WORD = "groupremoveperson";
+    public static final String MESSAGE_SUCCESS = "Member(s) removed from group";
+    public static final String MESSAGE_ERROR = "Person(s) not removed from group."
+                                                + "Be sure to use the exact names of group members";
+    public static final String MESSAGE_USAGE = "groupremoveperson gn/[GROUPNAME] n/[NAME1] n/[OPTIONAL NAME2]";
+
+    private final GroupName groupName;
+    private final ArrayList<Person> membersToBeRemoved;
+    private final boolean isValidCommand;
+
+    /**
+     * Creates a GroupRemovePersonCommand to add the specified {@code Person}
+     */
+    public GroupRemovePersonCommand(GroupName groupName, ArrayList<Person> membersToBeRemoved, boolean isValidCommand) {
+        requireAllNonNull(groupName, membersToBeRemoved, isValidCommand);
+        this.groupName = groupName;
+        this.membersToBeRemoved = membersToBeRemoved;
+        this.isValidCommand = isValidCommand;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        if (!isValidCommand) {
+            throw new CommandException(MESSAGE_ERROR);
+        }
+
+        Group oldGroup = model.getGroupByName(groupName);
+        ArrayList<Person> membersFromOldGroup = oldGroup.getMembers();
+        ArrayList<Person> remainingMembers = removeMembers(membersFromOldGroup, membersToBeRemoved);
+        Group newGroup = new Group(groupName, remainingMembers, oldGroup.getTags());
+        model.deleteGroup(oldGroup);
+        model.addGroup(newGroup);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof GroupAddPersonCommand)) {
+            return false;
+        }
+        GroupAddPersonCommand otherCommand = (GroupAddPersonCommand) other;
+        if (this.isValidCommand == (otherCommand.getValidCommand())
+                && checkSameMembers(otherCommand.getNewMembers())
+                && this.groupName.equals(otherCommand.getGroupName())) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Returns int object tracking the number of non-matching members between this.newMembers and otherMembers.
+     *
+     * @param numberOfNonMatchingMembers int value to track the number of members in otherMembers
+     *                                   that are not present in this.members.
+     * @param member Person object that is being searched for in otherMembers.
+     * @param otherMembers List of Person objects from another instance of CreateGroupCommand.
+     * @return int object to track the number of members in otherMembers that are not present in this.newMembers.
+     */
+    public int checkForMember(int numberOfNonMatchingMembers, Person member, ArrayList<Person> otherMembers) {
+        for (Person otherMember : otherMembers) {
+            if (member.equals(otherMember)) {
+                numberOfNonMatchingMembers--;
+                break;
+            }
+        }
+        return numberOfNonMatchingMembers;
+    }
+
+    /**
+     * Returns a boolean object representing if this.newMembers contains the same Person objects as otherMembers.
+     *
+     * @param otherMembers List of Person objects from another instance of CreateGroupCommand.
+     * @return boolean object representing if this.newMembers contains the same Person objects as otherMembers.
+     */
+    public boolean checkSameMembers(ArrayList<Person> otherMembers) {
+        int numberOfNonMatchingMembers = otherMembers.size();
+        for (Person member : this.membersToBeRemoved) {
+            numberOfNonMatchingMembers = checkForMember(numberOfNonMatchingMembers, member, otherMembers);
+        }
+        return numberOfNonMatchingMembers == 0;
+    }
+
+    /**
+     * Returns List of Person objects representing the remaining members after removing a given list of members.
+     *
+     * @param membersFromOldGroup List of Person objects representing original members in a group.
+     * @param membersToBeRemoved List of Person objects representing members to be removed from a group.
+     * @return List of Person objects representing the remaining members after removing a given list of members
+     * @throws CommandException If member to be removed is not present in the List of original members.
+     */
+    public ArrayList<Person> removeMembers(ArrayList<Person> membersFromOldGroup,
+                                           ArrayList<Person> membersToBeRemoved) throws CommandException {
+        ArrayList<Person> remainingMembers = new ArrayList<>(membersFromOldGroup);
+        for (Person memberToBeRemoved : membersToBeRemoved) {
+            boolean memberToBeRemovedIsPresent = remainingMembers.remove(memberToBeRemoved);
+            if (!memberToBeRemovedIsPresent) {
+                throw new CommandException(MESSAGE_ERROR);
+            }
+        }
+        return remainingMembers;
+    }
+}

--- a/src/main/java/seedu/awe/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/awe/logic/parser/AddressBookParser.java
@@ -19,6 +19,7 @@ import seedu.awe.logic.commands.ExitCommand;
 import seedu.awe.logic.commands.FindContactsCommand;
 import seedu.awe.logic.commands.FindGroupsCommand;
 import seedu.awe.logic.commands.GroupAddPersonCommand;
+import seedu.awe.logic.commands.GroupRemovePersonCommand;
 import seedu.awe.logic.commands.HelpCommand;
 import seedu.awe.logic.commands.ListContactsCommand;
 import seedu.awe.logic.commands.ListExpensesCommand;
@@ -105,6 +106,9 @@ public class AddressBookParser {
 
         case GroupAddPersonCommand.COMMAND_WORD:
             return new GroupAddPersonCommandParser(model).parse(arguments);
+
+        case GroupRemovePersonCommand.COMMAND_WORD:
+            return new GroupRemovePersonCommandParser(model).parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/awe/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/awe/logic/parser/AddressBookParser.java
@@ -18,6 +18,7 @@ import seedu.awe.logic.commands.EditContactCommand;
 import seedu.awe.logic.commands.ExitCommand;
 import seedu.awe.logic.commands.FindContactsCommand;
 import seedu.awe.logic.commands.FindGroupsCommand;
+import seedu.awe.logic.commands.GroupAddPersonCommand;
 import seedu.awe.logic.commands.HelpCommand;
 import seedu.awe.logic.commands.ListContactsCommand;
 import seedu.awe.logic.commands.ListExpensesCommand;
@@ -101,6 +102,9 @@ public class AddressBookParser {
 
         case AddExpenseCommand.COMMAND_WORD:
             return new AddExpenseCommandParser().parse(arguments);
+
+        case GroupAddPersonCommand.COMMAND_WORD:
+            return new GroupAddPersonCommandParser(model).parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/awe/logic/parser/CreateGroupCommandParser.java
+++ b/src/main/java/seedu/awe/logic/parser/CreateGroupCommandParser.java
@@ -52,7 +52,7 @@ public class CreateGroupCommandParser implements Parser<CreateGroupCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_GROUP_NAME, PREFIX_NAME, PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_GROUP_NAME, PREFIX_NAME)
+        if (!ParserUtil.arePrefixesPresent(argMultimap, PREFIX_GROUP_NAME, PREFIX_NAME)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateGroupCommand.MESSAGE_USAGE));
         }
@@ -102,7 +102,7 @@ public class CreateGroupCommandParser implements Parser<CreateGroupCommand> {
      *
      * @param memberName Name object representing name of member to be added.
      */
-    public boolean addMemberIfExist(Name memberName) {
+    public boolean addMemberIfExist(Name memberName) throws ParseException {
         boolean added = false;
         Person memberFound = findMember(memberName, this.allMembers);
         Stream<Name> namesOfMembers = this.toBeAddedToGroup.stream().map(member -> member.getName());
@@ -110,6 +110,9 @@ public class CreateGroupCommandParser implements Parser<CreateGroupCommand> {
         if (!Objects.isNull(memberFound) && numOfMembersWithSameName == 0) {
             toBeAddedToGroup.add(memberFound);
             added = true;
+        }
+        if (!added) {
+            throw new ParseException(MESSAGE_ERROR);
         }
         return added;
     }
@@ -129,13 +132,5 @@ public class CreateGroupCommandParser implements Parser<CreateGroupCommand> {
             }
         }
         return null;
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/awe/logic/parser/GroupAddPersonCommandParser.java
+++ b/src/main/java/seedu/awe/logic/parser/GroupAddPersonCommandParser.java
@@ -1,0 +1,124 @@
+package seedu.awe.logic.parser;
+import static seedu.awe.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.awe.logic.commands.GroupAddPersonCommand.MESSAGE_ERROR;
+import static seedu.awe.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
+import static seedu.awe.logic.parser.CliSyntax.PREFIX_NAME;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import javafx.collections.ObservableList;
+import seedu.awe.logic.commands.GroupAddPersonCommand;
+import seedu.awe.logic.parser.exceptions.ParseException;
+import seedu.awe.model.Model;
+import seedu.awe.model.ReadOnlyAddressBook;
+import seedu.awe.model.group.GroupName;
+import seedu.awe.model.person.Name;
+import seedu.awe.model.person.Person;
+
+public class GroupAddPersonCommandParser implements Parser<GroupAddPersonCommand> {
+    private static final String BAD_FORMATTING = "\"groupaddperson command\" is not properly formatted";
+    private ObservableList<Person> allMembers;
+    private final ArrayList<Person> newMembersToAdd;
+
+    /**
+     * Creates new GroupAddPersonCommandParser object.
+     *
+     * @param model Model object passed into constructor to provide list of contacts.
+     */
+    public GroupAddPersonCommandParser(Model model) {
+        ReadOnlyAddressBook addressBook = model.getAddressBook();
+        this.allMembers = addressBook.getPersonList();
+        this.newMembersToAdd = new ArrayList<>();
+    }
+
+    /**
+     * Returns GroupAddPersonCommand based on user input.
+     *
+     * @param args User input into addressbook.
+     * @return GroupAddPersonCommand object to represent command to be executed.
+     * @throws ParseException If user input is incorrectly formatted.
+     */
+    public GroupAddPersonCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_GROUP_NAME, PREFIX_NAME);
+
+        if (!ParserUtil.arePrefixesPresent(argMultimap, PREFIX_GROUP_NAME, PREFIX_NAME)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    GroupAddPersonCommand.MESSAGE_USAGE));
+        }
+
+        GroupName groupName = ParserUtil.parseGroupName(argMultimap.getValue(PREFIX_GROUP_NAME).get());
+        List<Name> newMemberNames = ParserUtil.parseMemberNames(argMultimap.getAllValues(PREFIX_NAME));
+        ArrayList<Person> newMembers = findNewMembers(newMemberNames);
+
+        boolean isValidCommand = true;
+        if (groupName.getName().equals(BAD_FORMATTING) || Objects.isNull(newMembers)) {
+            isValidCommand = false;
+        }
+
+        return new GroupAddPersonCommand(groupName, newMembers, isValidCommand);
+    }
+
+    /**
+     * Returns list of members in the group.
+     *
+     * @param newMemberNames List of names representing new members to be added into group.
+     * @return ArrayList of Person objects representing members to be added to the group
+     */
+    public ArrayList<Person> findNewMembers(List<Name> newMemberNames) throws ParseException {
+        try {
+            for (Name name : newMemberNames) {
+                addMemberIfExist(name);
+            }
+            if (!newMemberNames.isEmpty() && newMembersToAdd.isEmpty()) {
+                throw new ParseException(MESSAGE_ERROR);
+            }
+            return newMembersToAdd;
+        } catch (IndexOutOfBoundsException e) {
+            throw new ParseException(MESSAGE_INVALID_COMMAND_FORMAT);
+        }
+    }
+
+    /**
+     * Returns boolean object representing if member has been added into newMembersToAdd.
+     *
+     * @param memberName Name object representing member whose presence is being checked for.
+     * @return boolean object representing if member has been added into newMembersToAdd.
+     * @throws ParseException if the person does not exist in the contact list.
+     */
+    public boolean addMemberIfExist(Name memberName) throws ParseException {
+        boolean added = false;
+        Person memberFound = findMember(memberName, allMembers);
+        Stream<Name> namesOfMembers = newMembersToAdd.stream().map(member -> member.getName());
+        long numOfMembersWithSameName = namesOfMembers.filter(existingName -> existingName.equals(memberName)).count();
+        if (!Objects.isNull(memberFound) && numOfMembersWithSameName == 0) {
+            newMembersToAdd.add(memberFound);
+            added = true;
+        }
+        if (!added) {
+            throw new ParseException(GroupAddPersonCommand.MESSAGE_ERROR);
+        }
+        return added;
+    }
+
+    /**
+     * Returns person that matches a given Name object if in contact list.
+     * If person not in contact list, null is returned.
+     *
+     * @param memberName Name object representing person that is being searched for in the contact list.
+     * @param members ObservableList of Person objects representing all contacts in the contact list.
+     * @return Person object if name matches that of a person from the contact list.
+     */
+    public static Person findMember(Name memberName, ObservableList<Person> members) {
+        for (Person member : members) {
+            if (member.getName().equals(memberName)) {
+                return member;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/seedu/awe/logic/parser/GroupRemovePersonCommandParser.java
+++ b/src/main/java/seedu/awe/logic/parser/GroupRemovePersonCommandParser.java
@@ -1,6 +1,6 @@
 package seedu.awe.logic.parser;
 import static seedu.awe.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.awe.logic.commands.GroupAddPersonCommand.MESSAGE_ERROR;
+import static seedu.awe.logic.commands.GroupRemovePersonCommand.MESSAGE_ERROR;
 import static seedu.awe.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
 import static seedu.awe.logic.parser.CliSyntax.PREFIX_NAME;
 
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Objects;
 
 import javafx.collections.ObservableList;
-import seedu.awe.logic.commands.GroupAddPersonCommand;
+import seedu.awe.logic.commands.GroupRemovePersonCommand;
 import seedu.awe.logic.parser.exceptions.ParseException;
 import seedu.awe.model.Model;
 import seedu.awe.model.ReadOnlyAddressBook;
@@ -17,87 +17,87 @@ import seedu.awe.model.group.GroupName;
 import seedu.awe.model.person.Name;
 import seedu.awe.model.person.Person;
 
-public class GroupAddPersonCommandParser implements Parser<GroupAddPersonCommand> {
+public class GroupRemovePersonCommandParser implements Parser<GroupRemovePersonCommand> {
     private static final String BAD_FORMATTING = "\"groupaddperson command\" is not properly formatted";
     private ObservableList<Person> allMembers;
-    private final ArrayList<Person> newMembersToAdd;
+    private final ArrayList<Person> membersToBeRemoved;
 
     /**
-     * Creates new GroupAddPersonCommandParser object.
+     * Creates new GroupRemovePersonCommandParser object.
      *
      * @param model Model object passed into constructor to provide list of contacts.
      */
-    public GroupAddPersonCommandParser(Model model) {
+    public GroupRemovePersonCommandParser(Model model) {
         ReadOnlyAddressBook addressBook = model.getAddressBook();
         this.allMembers = addressBook.getPersonList();
-        this.newMembersToAdd = new ArrayList<>();
+        this.membersToBeRemoved = new ArrayList<>();
     }
 
     /**
-     * Returns GroupAddPersonCommand based on user input.
+     * Returns GroupRemovePersonCommand based on user input.
      *
      * @param args User input into addressbook.
-     * @return GroupAddPersonCommand object to represent command to be executed.
+     * @return GroupRemovePersonCommand object to represent command to be executed.
      * @throws ParseException If user input is incorrectly formatted.
      */
-    public GroupAddPersonCommand parse(String args) throws ParseException {
+    public GroupRemovePersonCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_GROUP_NAME, PREFIX_NAME);
 
         if (!ParserUtil.arePrefixesPresent(argMultimap, PREFIX_GROUP_NAME, PREFIX_NAME)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    GroupAddPersonCommand.MESSAGE_USAGE));
+                    GroupRemovePersonCommand.MESSAGE_USAGE));
         }
 
         GroupName groupName = ParserUtil.parseGroupName(argMultimap.getValue(PREFIX_GROUP_NAME).get());
-        List<Name> newMemberNames = ParserUtil.parseMemberNames(argMultimap.getAllValues(PREFIX_NAME));
-        ArrayList<Person> newMembers = findNewMembers(newMemberNames);
+        List<Name> membersToBeRemovedNames = ParserUtil.parseMemberNames(argMultimap.getAllValues(PREFIX_NAME));
 
+        ArrayList<Person> membersToBeRemoved = findMembersToBeRemoved(membersToBeRemovedNames);
         boolean isValidCommand = true;
-        if (groupName.getName().equals(BAD_FORMATTING) || Objects.isNull(newMembers)) {
+        if (groupName.getName().equals(BAD_FORMATTING) || Objects.isNull(membersToBeRemoved)) {
             isValidCommand = false;
         }
 
-        return new GroupAddPersonCommand(groupName, newMembers, isValidCommand);
+        return new GroupRemovePersonCommand(groupName, membersToBeRemoved, isValidCommand);
     }
 
     /**
      * Returns list of members in the group.
      *
-     * @param newMemberNames List of names representing new members to be added into group.
+     * @param membersToBeRemovedNames List of names representing members to be removed from group.
      * @return ArrayList of Person objects representing members to be added to the group
      */
-    public ArrayList<Person> findNewMembers(List<Name> newMemberNames) throws ParseException {
+    public ArrayList<Person> findMembersToBeRemoved(List<Name> membersToBeRemovedNames) throws ParseException {
         try {
-            for (Name name : newMemberNames) {
-                addMemberIfExist(name);
+            for (Name name : membersToBeRemovedNames) {
+                addMemberToRemoveList(name);
             }
-            if (!newMemberNames.isEmpty() && newMembersToAdd.isEmpty()) {
+            if (!membersToBeRemovedNames.isEmpty() && membersToBeRemovedNames.isEmpty()) {
                 throw new ParseException(MESSAGE_ERROR);
             }
-            return newMembersToAdd;
+            return membersToBeRemoved;
         } catch (IndexOutOfBoundsException e) {
             throw new ParseException(MESSAGE_INVALID_COMMAND_FORMAT);
         }
     }
 
     /**
-     * Returns boolean object representing if member has been added into newMembersToAdd.
+     * Returns boolean object representing if member has been added into this.membersToBeRemoved.
      *
      * @param memberName Name object representing member whose presence is being checked for.
-     * @return boolean object representing if member has been added into newMembersToAdd.
+     * @return boolean object representing if member has been added into this.membersToBeRemoved.
      * @throws ParseException if the person does not exist in the contact list.
      */
-    public boolean addMemberIfExist(Name memberName) throws ParseException {
+    public boolean addMemberToRemoveList(Name memberName) throws ParseException {
         boolean added = false;
         Person memberFound = findMember(memberName, allMembers);
         if (!Objects.isNull(memberFound)) {
-            newMembersToAdd.add(memberFound);
+            membersToBeRemoved.add(memberFound);
             added = true;
         }
         if (!added) {
-            throw new ParseException(GroupAddPersonCommand.MESSAGE_ERROR);
+            throw new ParseException(GroupRemovePersonCommand.MESSAGE_ERROR);
         }
         return added;
     }

--- a/src/main/java/seedu/awe/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/awe/logic/parser/ParserUtil.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import seedu.awe.commons.core.index.Index;
 import seedu.awe.commons.util.StringUtil;
@@ -203,5 +204,13 @@ public class ParserUtil {
             throw new ParseException(GroupName.MESSAGE_CONSTRAINTS);
         }
         return new Description(trimmedDescription);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    public static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/test/java/seedu/awe/logic/parser/CreateGroupCommandParserTest.java
+++ b/src/test/java/seedu/awe/logic/parser/CreateGroupCommandParserTest.java
@@ -1,7 +1,6 @@
 package seedu.awe.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.awe.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.awe.logic.commands.CommandTestUtil.GROUPNAME_DESC_BALI;
@@ -137,15 +136,19 @@ public class CreateGroupCommandParserTest {
         members.add(AMY);
         members.add(ALICE);
         assertEquals(parser.findGroupMembers(membersToFind), members);
-
-        resetParser();
-        //valid names and additional person not found in the model addressbook.
-        membersToFind.add(NONEXISTENTPERSON.getName());
-        assertEquals(parser.findGroupMembers(membersToFind), members);
     }
 
     @Test
     public void findGroupMembers_invalidValues_failure() throws ParseException {
+        resetParser();
+        //valid names and additional person not found in the model addressbook.
+        ArrayList<Name> membersToFindExtra = new ArrayList<>();
+        membersToFindExtra.add(BOB.getName());
+        membersToFindExtra.add(AMY.getName());
+        membersToFindExtra.add(ALICE.getName());
+        membersToFindExtra.add(NONEXISTENTPERSON.getName());
+        assertThrows(ParseException.class, CreateGroupCommand.MESSAGE_ERROR, () ->
+                emptyParser.findGroupMembers(membersToFindExtra));
 
         //Argument membersToFind contains members but CreateGroupCommandParser has empty toBeAddedToGroup List.
         //Throws ParseException.
@@ -167,7 +170,7 @@ public class CreateGroupCommandParserTest {
     }
 
     @Test
-    public void addMemberIfExist_validValues_trueReturned() {
+    public void addMemberIfExist_validValues_trueReturned() throws ParseException {
         resetParser();
         //Add valid Person name (Bob)
         assertTrue(parser.addMemberIfExist(BOB.getName()));
@@ -177,23 +180,22 @@ public class CreateGroupCommandParserTest {
 
         //Add valid Person name (Amy)
         assertTrue(parser.addMemberIfExist(AMY.getName()));
-
-        //Attempts to add a repeat Bob name will return false
-        assertFalse(parser.addMemberIfExist(BOB.getName()));
     }
 
     @Test
-    public void addMemberIfExist_invalidValues_falseReturned() {
+    public void addMemberIfExist_invalidValues_parseExceptionThrown() throws ParseException {
         resetParser();
         //Add valid Person name (Bob)
         assertTrue(parser.addMemberIfExist(BOB.getName()));
 
-        //Attempts to add a repeat Bob name will return false
-        assertFalse(parser.addMemberIfExist(BOB.getName()));
+        //Attempts to add a repeat Bob name will throw parseException
+        assertThrows(ParseException.class, CreateGroupCommand.MESSAGE_ERROR, () ->
+                parser.addMemberIfExist(BOB.getName()));
 
         resetParser();
         //Add Person who does not exist
-        assertFalse(parser.addMemberIfExist(NONEXISTENTPERSON.getName()));
+        assertThrows(ParseException.class, CreateGroupCommand.MESSAGE_ERROR, () ->
+                parser.addMemberIfExist(NONEXISTENTPERSON.getName()));
     }
 
     @Test


### PR DESCRIPTION
Create Group functionality does not inform user of non-existent person.
Groups do not support adding of members after creation.

User might assume non-existent person is added into group.
Inconvenient for users to delete and create group again.

Throw ParseException if non-existent person is being added into group.
Add GroupAddPersonCommand and GroupAddPersonCommandParser.

User is informed of non-existent person being added into group.
User able to add new members into group after its creation.