### PR TITLE
Bug fixes to group related commands to display changes instantly

### DIFF
--- a/src/main/java/seedu/awe/logic/commands/CreateGroupCommand.java
+++ b/src/main/java/seedu/awe/logic/commands/CreateGroupCommand.java
@@ -94,6 +94,7 @@ public class CreateGroupCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_GROUP);
         }
         model.addGroup(group);
+        model.setAllMembersOfGroup(group);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 

--- a/src/main/java/seedu/awe/logic/commands/DeleteGroupCommand.java
+++ b/src/main/java/seedu/awe/logic/commands/DeleteGroupCommand.java
@@ -2,6 +2,7 @@ package seedu.awe.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.awe.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
+import static seedu.awe.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import seedu.awe.logic.commands.exceptions.CommandException;
 import seedu.awe.model.Model;
@@ -45,9 +46,10 @@ public class DeleteGroupCommand extends Command {
 
         Group groupFromInternalList = model.getGroupByName(group.getGroupName());
         model.deleteGroup(groupFromInternalList);
+        model.setAllMembersOfGroup(groupFromInternalList);
         int numberOfMembers = groupFromInternalList.getMembers().size();
         String groupName = groupFromInternalList.getGroupName().getName();
-
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_SUCCESS, groupName, numberOfMembers));
     }
 

--- a/src/main/java/seedu/awe/logic/commands/GroupAddPersonCommand.java
+++ b/src/main/java/seedu/awe/logic/commands/GroupAddPersonCommand.java
@@ -97,8 +97,8 @@ public class GroupAddPersonCommand extends Command {
         }
         newMembers.addAll(membersFromOldGroup);
         Group newGroup = new Group(groupName, newMembers, oldGroup.getTags());
-        model.deleteGroup(oldGroup);
-        model.addGroup(newGroup);
+        model.setGroup(oldGroup, newGroup);
+        model.setAllMembersOfGroup(newGroup);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 

--- a/src/main/java/seedu/awe/logic/commands/GroupEditNameCommand.java
+++ b/src/main/java/seedu/awe/logic/commands/GroupEditNameCommand.java
@@ -55,8 +55,8 @@ public class GroupEditNameCommand extends Command {
             throw new CommandException(String.format(MESSAGE_NONEXISTENT_GROUP, oldGroupName));
         }
         Group newGroup = new Group(newGroupName, oldGroup.getMembers(), oldGroup.getTags());
-        model.deleteGroup(oldGroup);
-        model.addGroup(newGroup);
+        model.setGroup(oldGroup, newGroup);
+        model.setAllMembersOfGroup(newGroup);
         return new CommandResult(String.format(MESSAGE_SUCCESS, newGroupName));
     }
 

--- a/src/main/java/seedu/awe/logic/commands/GroupRemovePersonCommand.java
+++ b/src/main/java/seedu/awe/logic/commands/GroupRemovePersonCommand.java
@@ -101,8 +101,8 @@ public class GroupRemovePersonCommand extends Command {
         ArrayList<Person> membersFromOldGroup = oldGroup.getMembers();
         ArrayList<Person> remainingMembers = removeMembers(membersFromOldGroup, membersToBeRemoved);
         Group newGroup = new Group(groupName, remainingMembers, oldGroup.getTags());
-        model.deleteGroup(oldGroup);
-        model.addGroup(newGroup);
+        model.setGroup(oldGroup, newGroup);
+        model.setAllMembersOfGroup(oldGroup);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 

--- a/src/main/java/seedu/awe/model/Model.java
+++ b/src/main/java/seedu/awe/model/Model.java
@@ -80,10 +80,18 @@ public interface Model {
 
     /**
      * Replaces the given person {@code target} with {@code editedPerson}.
-     * {@code target} must exist in the awe book.
+     * {@code target} must exist in the awe contact list.
      * The person identity of {@code editedPerson} must not be the same as another existing person in the awe book.
      */
     void setPerson(Person target, Person editedPerson);
+
+    /**
+     * Replaces Person objects with updated Person objects within the {@code group}.
+     * {@code group} must exist in the awe group list.
+     *
+     * @param group Group object containing members to be updated.
+     */
+    void setAllMembersOfGroup(Group group);
 
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();

--- a/src/main/java/seedu/awe/model/ModelManager.java
+++ b/src/main/java/seedu/awe/model/ModelManager.java
@@ -121,6 +121,15 @@ public class ModelManager implements Model {
         addressBook.setPerson(target, editedPerson);
     }
 
+    @Override
+    public void setAllMembersOfGroup(Group group) {
+        requireNonNull(group);
+
+        for (Person member : group.getMembers()) {
+            addressBook.setPerson(member, member);
+        }
+    }
+
     //=========== Filtered Person List Accessors =============================================================
 
     /**

--- a/src/test/java/seedu/awe/logic/commands/AddContactCommandTest.java
+++ b/src/test/java/seedu/awe/logic/commands/AddContactCommandTest.java
@@ -144,6 +144,11 @@ public class AddContactCommandTest {
         }
 
         @Override
+        public void setAllMembersOfGroup(Group group) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Person> getFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/awe/logic/commands/AddExpenseCommandTest.java
+++ b/src/test/java/seedu/awe/logic/commands/AddExpenseCommandTest.java
@@ -261,6 +261,11 @@ public class AddExpenseCommandTest {
         }
 
         @Override
+        public void setAllMembersOfGroup(Group group) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Person> getFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/awe/logic/commands/CreateGroupCommandTest.java
+++ b/src/test/java/seedu/awe/logic/commands/CreateGroupCommandTest.java
@@ -154,6 +154,11 @@ public class CreateGroupCommandTest {
         }
 
         @Override
+        public void setAllMembersOfGroup(Group group) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Person> getFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
         }
@@ -268,6 +273,11 @@ public class CreateGroupCommandTest {
         @Override
         public ReadOnlyAddressBook getAddressBook() {
             return new AddressBook();
+        }
+
+        @Override
+        public void setAllMembersOfGroup(Group group) {
+            requireNonNull(group);
         }
     }
 


### PR DESCRIPTION
All group related commands do not immediately update information
shown on GUI.
Information only updated when user clicks on relevant panels.

User interface needs to be more responsive and immediately display
updated information.

Add setAllPersonInGroup method to model.
Sets all members of group in the model upon issueing group command.

Group related commands instantly update information.