### PR TITLE
Add group add/remove tag functionality

### DIFF
--- a/src/main/java/seedu/awe/logic/commands/GroupAddTagCommand.java
+++ b/src/main/java/seedu/awe/logic/commands/GroupAddTagCommand.java
@@ -1,0 +1,117 @@
+package seedu.awe.logic.commands;
+import static java.util.Objects.requireNonNull;
+import static seedu.awe.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Objects;
+import java.util.Set;
+
+import seedu.awe.logic.commands.exceptions.CommandException;
+import seedu.awe.model.Model;
+import seedu.awe.model.group.Group;
+import seedu.awe.model.group.GroupName;
+import seedu.awe.model.tag.Tag;
+
+public class GroupAddTagCommand extends Command {
+    public static final String COMMAND_WORD = "groupaddtag";
+    public static final String MESSAGE_SUCCESS = "New tag(s) added to group";
+    public static final String MESSAGE_DUPLICATE_TAG = "%1$s is already in the group";
+    public static final String MESSAGE_USAGE = "groupaddtag gn/[GROUPNAME] n/[TAG1] n/[OPTIONAL TAG2]";
+    public static final String MESSAGE_NONEXISTENT_GROUP = "Group %1$s does not exist.";
+
+    private final GroupName groupName;
+    private final Set<Tag> newTags;
+    private final boolean isValidCommand;
+
+    /**
+     * Creates a GroupAddTagCommand to add the specified {@code Tag}
+     */
+    public GroupAddTagCommand(GroupName groupName, Set<Tag> newTags, boolean isValidCommand) {
+        requireAllNonNull(groupName, newTags, isValidCommand);
+        this.groupName = groupName;
+        this.newTags = newTags;
+        this.isValidCommand = isValidCommand;
+    }
+
+    public GroupName getGroupName() {
+        return groupName;
+    }
+
+    public Set<Tag> getNewTags() {
+        return newTags;
+    }
+
+    public boolean getValidCommand() {
+        return isValidCommand;
+    }
+
+    /**
+     * Returns int object tracking the number of non-matching tags between this.newTags and otherTags.
+     *
+     * @param numberOfNonMatchingTags int value to track the number of tags in otherTags
+     *                                   that are not present in this.newTags.
+     * @param tag Tag object that is being searched for in otherTags.
+     * @param otherTags List of Tag objects from another instance of GroupAddTagCommand.
+     * @return int object to track the number of tags in otherTags that are not present in this.newTags.
+     */
+    public int checkForTag(int numberOfNonMatchingTags, Tag tag, Set<Tag> otherTags) {
+        for (Tag otherTag : otherTags) {
+            if (tag.equals(otherTag)) {
+                numberOfNonMatchingTags--;
+                break;
+            }
+        }
+        return numberOfNonMatchingTags;
+    }
+
+    /**
+     * Returns a boolean object representing if this.newTags contains the same Tag objects as otherTags.
+     *
+     * @param otherTags List of Tag objects from another instance of GroupAddTagCommand.
+     * @return boolean object representing if this.newTags contains the same Tag objects as otherTags.
+     */
+    public boolean checkSameTags(Set<Tag> otherTags) {
+        int numberOfNonMatchingTags = otherTags.size();
+        for (Tag tag : this.newTags) {
+            checkForTag(numberOfNonMatchingTags, tag, otherTags);
+        }
+        return numberOfNonMatchingTags == 0;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        if (!isValidCommand) {
+            throw new CommandException(Tag.MESSAGE_CONSTRAINTS);
+        }
+
+        Group oldGroup = model.getGroupByName(groupName);
+        if (Objects.isNull(oldGroup)) {
+            throw new CommandException(String.format(MESSAGE_NONEXISTENT_GROUP, groupName));
+        }
+        Set<Tag> tagsFromOldGroup = oldGroup.getTags();
+        for (Tag tag : newTags) {
+            if (tagsFromOldGroup.contains(tag)) {
+                throw new CommandException(String.format(MESSAGE_DUPLICATE_TAG, tag.getTagName()));
+            }
+        }
+        newTags.addAll(tagsFromOldGroup);
+        Group newGroup = new Group(groupName, oldGroup.getMembers(), newTags);
+        model.setGroup(oldGroup, newGroup);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof GroupAddPersonCommand)) {
+            return false;
+        }
+        GroupAddTagCommand otherCommand = (GroupAddTagCommand) other;
+        if (this.isValidCommand == otherCommand.getValidCommand()
+                && checkSameTags(otherCommand.getNewTags())
+                && this.groupName.equals(otherCommand.getGroupName())) {
+            return true;
+        }
+        return false;
+    }
+}
+

--- a/src/main/java/seedu/awe/logic/commands/GroupRemoveTagCommand.java
+++ b/src/main/java/seedu/awe/logic/commands/GroupRemoveTagCommand.java
@@ -1,0 +1,133 @@
+package seedu.awe.logic.commands;
+import static java.util.Objects.requireNonNull;
+import static seedu.awe.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import seedu.awe.logic.commands.exceptions.CommandException;
+import seedu.awe.model.Model;
+import seedu.awe.model.group.Group;
+import seedu.awe.model.group.GroupName;
+import seedu.awe.model.tag.Tag;
+
+public class GroupRemoveTagCommand extends Command {
+    public static final String COMMAND_WORD = "groupremovetag";
+    public static final String MESSAGE_SUCCESS = "Tag(s) removed from group";
+    public static final String MESSAGE_ERROR = "Tag(s) not removed from group. Make sure to use exact tag names.";
+    public static final String MESSAGE_NONEXISTENT_TAG = "The tag \"%1$s\" is not found in the group.";
+    public static final String MESSAGE_USAGE = "groupaddtag gn/[GROUPNAME] n/[TAG1] n/[OPTIONAL TAG2]";
+    public static final String MESSAGE_NONEXISTENT_GROUP = "Group %1$s does not exist.";
+
+    private final GroupName groupName;
+    private final Set<Tag> tagsToBeRemoved;
+    private final boolean isValidCommand;
+
+    /**
+     * Creates a GroupRemoveTagCommand to remove the specified {@code Tag}
+     */
+    public GroupRemoveTagCommand(GroupName groupName, Set<Tag> tagsToBeRemoved, boolean isValidCommand) {
+        requireAllNonNull(groupName, tagsToBeRemoved, isValidCommand);
+        this.groupName = groupName;
+        this.tagsToBeRemoved = tagsToBeRemoved;
+        this.isValidCommand = isValidCommand;
+    }
+
+    public GroupName getGroupName() {
+        return groupName;
+    }
+
+    public Set<Tag> getTagsToBeRemoved() {
+        return tagsToBeRemoved;
+    }
+
+    public boolean getValidCommand() {
+        return isValidCommand;
+    }
+
+    /**
+     * Returns int object tracking the number of non-matching tags between this.tagsToBeRemoved and otherTags.
+     *
+     * @param numberOfNonMatchingTags int value to track the number of tags in otherTags
+     *                                   that are not present in this.tagsToBeRemoved.
+     * @param tag Tag object that is being searched for in otherTags.
+     * @param otherTags List of Tag objects from another instance of GroupRemoveTagCommand.
+     * @return int object to track the number of tags in otherTags that are not present in this.tagsToBeRemoved.
+     */
+    public int checkForTag(int numberOfNonMatchingTags, Tag tag, Set<Tag> otherTags) {
+        for (Tag otherTag : otherTags) {
+            if (tag.equals(otherTag)) {
+                numberOfNonMatchingTags--;
+                break;
+            }
+        }
+        return numberOfNonMatchingTags;
+    }
+
+    /**
+     * Returns a boolean object representing if this.tagsToBeRemoved contains the same Tag objects as otherTags.
+     *
+     * @param otherTags List of Tag objects from another instance of GroupRemoveTagCommand.
+     * @return boolean object representing if this.tagsToBeRemoved contains the same Tag objects as otherTags.
+     */
+    public boolean checkSameTags(Set<Tag> otherTags) {
+        int numberOfNonMatchingTags = otherTags.size();
+        for (Tag tag : this.tagsToBeRemoved) {
+            checkForTag(numberOfNonMatchingTags, tag, otherTags);
+        }
+        return numberOfNonMatchingTags == 0;
+    }
+
+    /**
+     * Returns Set of Tag objects representing the remaining tags after removing a given set of tags.
+     *
+     * @param tagsFromOldGroup Set of Tag objects representing original tags in a group.
+     * @param tagsToBeRemoved Set of Tag objects representing tags to be removed from a group.
+     * @return Set of Tag objects representing the remaining tags after removing a given set of tags
+     * @throws CommandException If tag to be removed is not present in the set of original tags.
+     */
+    public Set<Tag> removeTags(Set<Tag> tagsFromOldGroup, Set<Tag> tagsToBeRemoved) throws CommandException {
+        Set<Tag> remainingTags = new HashSet<>(tagsFromOldGroup);
+        for (Tag tagToBeRemoved : tagsToBeRemoved) {
+            boolean tagToBeRemovedIsPresent = remainingTags.remove(tagToBeRemoved);
+            if (!tagToBeRemovedIsPresent) {
+                throw new CommandException(String.format(MESSAGE_NONEXISTENT_TAG, tagToBeRemoved.getTagName()));
+            }
+        }
+        return remainingTags;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        if (!isValidCommand) {
+            throw new CommandException(MESSAGE_ERROR);
+        }
+
+        Group oldGroup = model.getGroupByName(groupName);
+        if (Objects.isNull(oldGroup)) {
+            throw new CommandException(String.format(MESSAGE_NONEXISTENT_GROUP, groupName));
+        }
+        Set<Tag> tagsFromOldGroup = oldGroup.getTags();
+        Set<Tag> remainingTags = removeTags(tagsFromOldGroup, tagsToBeRemoved);
+        Group newGroup = new Group(groupName, oldGroup.getMembers(), remainingTags);
+        model.setGroup(oldGroup, newGroup);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof GroupAddPersonCommand)) {
+            return false;
+        }
+        GroupAddTagCommand otherCommand = (GroupAddTagCommand) other;
+        if (this.isValidCommand == otherCommand.getValidCommand()
+                && checkSameTags(otherCommand.getNewTags())
+                && this.groupName.equals(otherCommand.getGroupName())) {
+            return true;
+        }
+        return false;
+    }
+}
+

--- a/src/main/java/seedu/awe/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/awe/logic/parser/AddressBookParser.java
@@ -127,7 +127,7 @@ public class AddressBookParser {
 
         case GroupRemoveTagCommand.COMMAND_WORD:
             return new GroupRemoveTagCommandParser().parse(arguments);
-            
+
         case ListTransactionSummaryCommand.COMMAND_WORD:
             return new ListTransactionSummaryCommandParser().parse(arguments);
 

--- a/src/main/java/seedu/awe/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/awe/logic/parser/AddressBookParser.java
@@ -20,8 +20,10 @@ import seedu.awe.logic.commands.FindContactsCommand;
 import seedu.awe.logic.commands.FindExpensesCommand;
 import seedu.awe.logic.commands.FindGroupsCommand;
 import seedu.awe.logic.commands.GroupAddPersonCommand;
+import seedu.awe.logic.commands.GroupAddTagCommand;
 import seedu.awe.logic.commands.GroupEditNameCommand;
 import seedu.awe.logic.commands.GroupRemovePersonCommand;
+import seedu.awe.logic.commands.GroupRemoveTagCommand;
 import seedu.awe.logic.commands.HelpCommand;
 import seedu.awe.logic.commands.ListContactsCommand;
 import seedu.awe.logic.commands.ListExpensesCommand;
@@ -117,6 +119,12 @@ public class AddressBookParser {
 
         case GroupEditNameCommand.COMMAND_WORD:
             return new GroupEditNameCommandParser().parse(arguments);
+
+        case GroupAddTagCommand.COMMAND_WORD:
+            return new GroupAddTagCommandParser().parse(arguments);
+
+        case GroupRemoveTagCommand.COMMAND_WORD:
+            return new GroupRemoveTagCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/awe/logic/parser/GroupAddPersonCommandParser.java
+++ b/src/main/java/seedu/awe/logic/parser/GroupAddPersonCommandParser.java
@@ -40,6 +40,7 @@ public class GroupAddPersonCommandParser implements Parser<GroupAddPersonCommand
      * @return GroupAddPersonCommand object to represent command to be executed.
      * @throws ParseException If user input is incorrectly formatted.
      */
+    @Override
     public GroupAddPersonCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_GROUP_NAME, PREFIX_NAME);

--- a/src/main/java/seedu/awe/logic/parser/GroupAddTagCommandParser.java
+++ b/src/main/java/seedu/awe/logic/parser/GroupAddTagCommandParser.java
@@ -1,0 +1,45 @@
+package seedu.awe.logic.parser;
+import static seedu.awe.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.awe.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
+import static seedu.awe.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.Objects;
+import java.util.Set;
+
+import seedu.awe.logic.commands.GroupAddTagCommand;
+import seedu.awe.logic.parser.exceptions.ParseException;
+import seedu.awe.model.group.GroupName;
+import seedu.awe.model.tag.Tag;
+
+public class GroupAddTagCommandParser implements Parser<GroupAddTagCommand> {
+    private static final String BAD_FORMATTING = "\"groupaddtag command\" is not properly formatted";
+
+    /**
+     * Returns GroupAddTagCommand based on user input.
+     *
+     * @param args User input into contact list.
+     * @return GroupAddTagCommand object to represent command to be executed.
+     * @throws ParseException If user input is incorrectly formatted.
+     */
+    @Override
+    public GroupAddTagCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_GROUP_NAME, PREFIX_TAG);
+
+        if (!ParserUtil.arePrefixesPresent(argMultimap, PREFIX_GROUP_NAME, PREFIX_TAG)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    GroupAddTagCommand.MESSAGE_USAGE));
+        }
+
+        GroupName groupName = ParserUtil.parseGroupName(argMultimap.getValue(PREFIX_GROUP_NAME).get());
+        Set<Tag> newTagNames = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+
+        boolean isValidCommand = true;
+        if (groupName.getName().equals(BAD_FORMATTING) || Objects.isNull(newTagNames)) {
+            isValidCommand = false;
+        }
+
+        return new GroupAddTagCommand(groupName, newTagNames, isValidCommand);
+    }
+}

--- a/src/main/java/seedu/awe/logic/parser/GroupRemoveTagCommandParser.java
+++ b/src/main/java/seedu/awe/logic/parser/GroupRemoveTagCommandParser.java
@@ -1,0 +1,45 @@
+package seedu.awe.logic.parser;
+import static seedu.awe.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.awe.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
+import static seedu.awe.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.Objects;
+import java.util.Set;
+
+import seedu.awe.logic.commands.GroupRemoveTagCommand;
+import seedu.awe.logic.parser.exceptions.ParseException;
+import seedu.awe.model.group.GroupName;
+import seedu.awe.model.tag.Tag;
+
+public class GroupRemoveTagCommandParser implements Parser<GroupRemoveTagCommand> {
+    private static final String BAD_FORMATTING = "\"groupremovetag command\" is not properly formatted";
+
+    /**
+     * Returns GroupRemoveTagCommand based on user input.
+     *
+     * @param args User input into contact list.
+     * @return GroupRemoveTagCommand object to represent command to be executed.
+     * @throws ParseException If user input is incorrectly formatted.
+     */
+    @Override
+    public GroupRemoveTagCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_GROUP_NAME, PREFIX_TAG);
+
+        if (!ParserUtil.arePrefixesPresent(argMultimap, PREFIX_GROUP_NAME, PREFIX_TAG)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    GroupRemoveTagCommand.MESSAGE_USAGE));
+        }
+
+        GroupName groupName = ParserUtil.parseGroupName(argMultimap.getValue(PREFIX_GROUP_NAME).get());
+        Set<Tag> tagsToBeRemoved = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+
+        boolean isValidCommand = true;
+        if (groupName.getName().equals(BAD_FORMATTING) || Objects.isNull(tagsToBeRemoved)) {
+            isValidCommand = false;
+        }
+
+        return new GroupRemoveTagCommand(groupName, tagsToBeRemoved, isValidCommand);
+    }
+}

--- a/src/main/java/seedu/awe/model/tag/Tag.java
+++ b/src/main/java/seedu/awe/model/tag/Tag.java
@@ -32,6 +32,10 @@ public class Tag {
         return test.matches(VALIDATION_REGEX);
     }
 
+    public String getTagName() {
+        return tagName;
+    }
+
     @Override
     public boolean equals(Object other) {
         if (other == this) {


### PR DESCRIPTION
Tags are specified during creation of group.

User has no way to add or remove tags to an existing group.
Inconvenient for user to delete and create group to change tags.

Add group add/remove tag functionality.

Users able to modify tags within a group.